### PR TITLE
Update isInfixOf

### DIFF
--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -493,9 +493,11 @@ seqBenches = envp seqData $ \_ -> bgroup "Sequence"
     ]
   , bgroup "infixIndices full"
     [ bench "Seq" $ nf (join Seq.infixIndices) bigSeq
+    , bench "MSeq" $ nf (join Seq.infixIndices) bigSeq
     ]
   , bgroup "infixIndices all"
     [ bench "Seq" $ nf (Seq.infixIndices (Seq.singleton 0)) big0Seq
+    , bench "MSeq" $ nf (MSeq.infixIndices (MSeq.singleton 0)) big0MSeq
     ]
   , bgroup "sliceSummaryMay"
     [ bench "MSeq" $ whnf (F.foldr (\lu z -> MSeq.sliceSummaryMay lu bigMSeq `seq` z) ()) bigRandomRangeList
@@ -597,6 +599,7 @@ seqData =
     , medSeq
     )
   , ( bigMSeq
+    , big0MSeq
     , bigRandomMSeq
     , bigMSeqS
     )
@@ -656,6 +659,7 @@ medSeq = Seq.fromList medList
 
 bigMSeq, bigRandomMSeq :: MSeq.MSeq Int
 bigMSeq = MSeq.fromList bigList
+big0MSeq = MSeq.fromList big0List
 bigRandomMSeq = MSeq.fromList bigRandomList
 
 bigMSeqS :: MSeq.MSeq SumElem

--- a/bench/README.md
+++ b/bench/README.md
@@ -10,7 +10,7 @@ Below are comparisons of `seqn` with some alternatives.
 | `containers` | `Data.Sequence.Seq`     | No           | No           | Comparable<sup>[1]</sup> |
 | `rrb-vector` | `Data.RRBVector.Vector` | Yes          | No           | Comparable<sup>[2]</sup> |
 
-<sup>1</sup> Has asymptotically better complexity for access at either end  
+<sup>1</sup> Has asymptotically better complexity for access at either end
 <sup>2</sup> Slow at structural changes, but faster otherwise
 
 ### Measured sequence
@@ -122,8 +122,8 @@ unzipWith nf          │  242 μs   1x  │  143 μs  0.6x  │  484 μs    2x 
 mconcat               │  128 μs   1x  │                │  212 μs  1.6x  │   13 ms  105x  │
 binarySearchFind      │  395 μs   1x  │  395 μs    1x  │                │                │
 isPrefixOf            │  120 μs   1x  │  131 μs  1.1x  │                │                │
-infixIndices full     │  206 μs   1x  │                │                │                │
-infixIndices all      │  173 μs   1x  │                │                │                │
+infixIndices full     │  198 μs   1x  │  195 μs    1x  │                │                │
+infixIndices all      │  166 μs   1x  │  164 μs    1x  │                │                │
 sliceSummaryMay       │               │  586 μs    1x  │                │                │
 sliceSummary          │               │  604 μs    1x  │                │                │
 binarySearchPrefix    │               │  400 μs    1x  │                │                │

--- a/src/Data/Seqn/Internal/MSeq.hs
+++ b/src/Data/Seqn/Internal/MSeq.hs
@@ -863,16 +863,17 @@ infixIndices :: Eq a => MSeq a -> MSeq a -> [Int]
 infixIndices t1 t2
   | null t1 = [0 .. length t2]
   | compareLength t1 t2 == GT = []
-  | otherwise = X.build $ \lcons lnil ->
+  | otherwise =
     let n1 = length t1
         t1a = infixIndicesMkArray n1 t1
-        !(!mt, !mt0) = KMP.build t1a
-        f !i x k = \ !m -> case KMP.step mt m x of
-          (b,m') ->
-            if b
-            then lcons (i-n1+1) (k m')
-            else k m'
-    in IFo.ifoldr f (\ !_ -> lnil) t2 mt0
+        !(!mt, !m0) = KMP.build t1a
+    in X.build $ \lcons lnil ->
+         let f !i x k !m = case KMP.step mt m x of
+               (b,m') ->
+                 if b
+                 then lcons (i-n1+1) (k m')
+                 else k m'
+         in IFo.ifoldr f (\ !_ -> lnil) t2 m0
 {-# INLINE infixIndices #-} -- Inline for fusion
 
 infixIndicesMkArray :: Int -> MSeq a -> A.Array a
@@ -914,7 +915,7 @@ isSuffixOf t1 t2 =
 
 -- | \(O(n_1 + n_2)\). Whether the first sequence is a substring of the second.
 isInfixOf :: Eq a => MSeq a -> MSeq a -> Bool
-isInfixOf t1 t2 = not (null (infixIndices t1 t2))
+isInfixOf t1 t2 = foldr (\_ _ -> True) False (infixIndices t1 t2)
 {-# INLINABLE isInfixOf #-}
 
 -- | \(O(n_1 + n_2)\). Whether the first sequence is a subsequence of the second.


### PR DESCRIPTION
* Use foldr in isInfixOf because apparently null does not fuse.
* Move some definitions out of X.build in infixIndices, should not change anything.
* Add infixIndices benchmarks for MSeq.